### PR TITLE
オリジナルcontextをwrap

### DIFF
--- a/context/context.go
+++ b/context/context.go
@@ -1,0 +1,6 @@
+package context
+
+import "context"
+
+// Context wraps original context.
+type Context context.Context

--- a/service/user.go
+++ b/service/user.go
@@ -1,17 +1,16 @@
 package service
 
 import (
-	ctx "context"
 	"github.com/shinofara/simple-go-web-app/context"
 	"github.com/shinofara/simple-go-web-app/repository"
 	"github.com/shinofara/simple-go-web-app/entity"
 )
 
 type UserService struct {
-	ctx ctx.Context
+	ctx context.Context
 }
 
-func NewUser(ctx ctx.Context) *UserService {
+func NewUser(ctx context.Context) *UserService {
 	return &UserService{ctx}
 }
 


### PR DESCRIPTION
https://github.com/shinofara/simple-go-web-app/compare/wrap_context?expand=1#diff-fb9695c06ee98e88efa727c004ce7921L5

このように、importするcontextが、標準の物と、sub-packageのものとが混在した為、可読性が下がっていた。